### PR TITLE
Add calculated properties to groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,34 @@ You can then use this in your templates to do cool things like:
 ```
 
 **There is also an example in [test/dummy](tests/dummy).**
+
+## Custom properties
+Additionally, you can define custom properties to your group. These can be either plain values or functions. E.g.
+```javascript
+import Ember from 'ember';
+import groupBy from 'ember-group-by';
+
+export default Ember.Controller.extend({
+  carsByColor: groupBy('model', 'color', {
+    originalColor: 'black',
+    isBigGroup: function() {
+        return this.get('items').length > 2;
+  });
+});
+```
+Using these properties, you can do things like this:
+```handlebars
+<h1>Cars grouped by color</h1>
+
+{{#each carsByColor as |group|}}
+  <h3>Cars that have {{group.property}} {{group.value}}, that once were {{group.originalColor}}</h3>
+  {{#if group.isBigGroup}}
+    This will be a long list!
+  {{/if}}
+  <ul>
+    {{#each group.items as |car|}}
+      <li>{{car.name}}</li>
+    {{/each}}
+  </ul>
+{{/each}}
+```

--- a/addon/macros/group-by.js
+++ b/addon/macros/group-by.js
@@ -5,7 +5,15 @@ var computed = Ember.computed;
 var get = Ember.get;
 var isPresent = Ember.isPresent;
 
-export default function groupBy(collection, property) {
+// Standard group object is an Ember object, so we can
+// use get() and set() for properties
+var groupedList = Ember.Object.extend({
+  property: "",
+  items: [],
+  value: ""
+});
+
+export default function groupBy(collection, property, additionalProperties) {
   var dependentKey = collection + '.@each.' + property;
 
   return computed(dependentKey, function() {
@@ -19,7 +27,13 @@ export default function groupBy(collection, property) {
       if (isPresent(group)) {
         get(group, 'items').push(item);
       } else {
-        group = { property: property, value: value, items: [item] };
+        group = groupedList.create({
+          property: property,
+          value: value,
+          items: [item]
+        });
+        // Merge the additional properties in the group object
+        Ember.merge(group, additionalProperties);
         groups.push(group);
       }
     });

--- a/tests/unit/macros/group-by-test.js
+++ b/tests/unit/macros/group-by-test.js
@@ -29,17 +29,17 @@ test('it groups cars by color', function(assert) {
 
   var result = dealership.get('carsGroupedByColor');
   var expected = [redGroup, blueGroup, greenGroup];
-  assert.equal(result.objectAt(0).property, expected[0].property);
-  assert.equal(result.objectAt(0).value, expected[0].value);
-  assert.deepEqual(result.objectAt(0).items, expected[0].items);
+  assert.equal(result[0].property, expected[0].property);
+  assert.equal(result[0].value, expected[0].value);
+  assert.deepEqual(result[0].items, expected[0].items);
 
-  assert.equal(result.objectAt(1).property, expected[1].property);
-  assert.equal(result.objectAt(1).value, expected[1].value);
-  assert.deepEqual(result.objectAt(1).items, expected[1].items);
+  assert.equal(result[1].property, expected[1].property);
+  assert.equal(result[1].value, expected[1].value);
+  assert.deepEqual(result[1].items, expected[1].items);
 
-  assert.equal(result.objectAt(2).property, expected[2].property);
-  assert.equal(result.objectAt(2).value, expected[2].value);
-  assert.deepEqual(result.objectAt(2).items, expected[2].items);
+  assert.equal(result[2].property, expected[2].property);
+  assert.equal(result[2].value, expected[2].value);
+  assert.deepEqual(result[2].items, expected[2].items);
 });
 
 test('it applies custom attributes to the group', function(assert) {
@@ -59,18 +59,18 @@ test('it applies custom attributes to the group', function(assert) {
   var result = dealership.get('carsGroupedByColor');
   var expected = [redGroup, blueGroup, greenGroup];
 
-  assert.equal(result.objectAt(0).property, expected[0].property);
-  assert.equal(result.objectAt(0).value, expected[0].value);
-  assert.equal(result.objectAt(0).originalColor, expected[0].originalColor);
-  assert.deepEqual(result.objectAt(0).items, expected[0].items);
+  assert.equal(result[0].property, expected[0].property);
+  assert.equal(result[0].value, expected[0].value);
+  assert.equal(result[0].originalColor, expected[0].originalColor);
+  assert.deepEqual(result[0].items, expected[0].items);
 
-  assert.equal(result.objectAt(1).property, expected[1].property);
-  assert.equal(result.objectAt(1).value, expected[1].value);
-  assert.equal(result.objectAt(1).originalColor, expected[1].originalColor);
-  assert.deepEqual(result.objectAt(1).items, expected[1].items);
+  assert.equal(result[1].property, expected[1].property);
+  assert.equal(result[1].value, expected[1].value);
+  assert.equal(result[1].originalColor, expected[1].originalColor);
+  assert.deepEqual(result[1].items, expected[1].items);
 
-  assert.equal(result.objectAt(2).property, expected[2].property);
-  assert.equal(result.objectAt(2).value, expected[2].value);
-  assert.equal(result.objectAt(2).originalColor, expected[2].originalColor);
-  assert.deepEqual(result.objectAt(2).items, expected[2].items);
+  assert.equal(result[2].property, expected[2].property);
+  assert.equal(result[2].value, expected[2].value);
+  assert.equal(result[2].originalColor, expected[2].originalColor);
+  assert.deepEqual(result[2].items, expected[2].items);
 });

--- a/tests/unit/macros/group-by-test.js
+++ b/tests/unit/macros/group-by-test.js
@@ -74,3 +74,45 @@ test('it applies custom attributes to the group', function(assert) {
   assert.equal(result[2].originalColor, expected[2].originalColor);
   assert.deepEqual(result[2].items, expected[2].items);
 });
+
+test('it applies custom calculated properties to the group', function(assert) {
+  assert.expect(15);
+  dealership = Ember.Object.extend({
+    cars: cars,
+    carsGroupedByColor: groupBy('cars', 'color', {
+
+      isPrimaryColor: function() {
+        return (this.get('value') === 'green' || this.get('value') === 'red');
+      },
+      isBigGroup: function() {
+        return (this.get('items').length > 1);
+      }
+    })
+  }).create();
+
+  var redGroup = { property: 'color', value: 'red', items: [car1, car2], isPrimaryColor: true, isBigGroup: true };
+  var blueGroup = { property: 'color', value: 'blue', items: [car3, car4], isPrimaryColor: false, isBigGroup: true };
+  var greenGroup = { property: 'color', value: 'green', items: [car5], isPrimaryColor: true, isBigGroup: false };
+
+  var result = dealership.get('carsGroupedByColor');
+  var expected = [redGroup, blueGroup, greenGroup];
+
+  assert.equal(result[0].property, expected[0].property);
+  assert.equal(result[0].value, expected[0].value);
+  assert.equal(result[0].isPrimaryColor(), expected[0].isPrimaryColor);
+  assert.equal(result[0].isBigGroup(), expected[0].isBigGroup);
+  assert.deepEqual(result[0].items, expected[0].items);
+
+  assert.equal(result[1].property, expected[1].property);
+  assert.equal(result[1].value, expected[1].value);
+  assert.equal(result[1].isPrimaryColor(), expected[1].isPrimaryColor);
+  assert.equal(result[1].isBigGroup(), expected[1].isBigGroup);
+  assert.deepEqual(result[1].items, expected[1].items);
+
+  assert.equal(result[2].property, expected[2].property);
+  assert.equal(result[2].value, expected[2].value);
+  assert.equal(result[2].isPrimaryColor(), expected[2].isPrimaryColor);
+  assert.equal(result[2].isBigGroup(), expected[2].isBigGroup);
+  assert.deepEqual(result[2].items, expected[2].items);
+});
+

--- a/tests/unit/macros/group-by-test.js
+++ b/tests/unit/macros/group-by-test.js
@@ -22,13 +22,55 @@ module('Unit - groupBy', {
 });
 
 test('it groups cars by color', function(assert) {
-  assert.expect(1);
+  assert.expect(9);
   var redGroup = { property: 'color', value: 'red', items: [car1, car2] };
   var blueGroup = { property: 'color', value: 'blue', items: [car3, car4] };
   var greenGroup = { property: 'color', value: 'green', items: [car5] };
 
   var result = dealership.get('carsGroupedByColor');
   var expected = [redGroup, blueGroup, greenGroup];
+  assert.equal(result.objectAt(0).property, expected[0].property);
+  assert.equal(result.objectAt(0).value, expected[0].value);
+  assert.deepEqual(result.objectAt(0).items, expected[0].items);
 
-  assert.deepEqual(result, expected);
+  assert.equal(result.objectAt(1).property, expected[1].property);
+  assert.equal(result.objectAt(1).value, expected[1].value);
+  assert.deepEqual(result.objectAt(1).items, expected[1].items);
+
+  assert.equal(result.objectAt(2).property, expected[2].property);
+  assert.equal(result.objectAt(2).value, expected[2].value);
+  assert.deepEqual(result.objectAt(2).items, expected[2].items);
+});
+
+test('it applies custom attributes to the group', function(assert) {
+  assert.expect(12);
+  dealership = Ember.Object.extend({
+    cars: cars,
+    carsGroupedByColor: groupBy('cars', 'color', { originalColor: true })
+  }).create();
+
+  var redGroup = { property: 'color', value: 'red', items: [car1, car2], originalColor: true };
+  var blueGroup = { property: 'color', value: 'blue', items: [car3, car4], originalColor: true };
+  var greenGroup = { property: 'color', value: 'green', items: [car5], originalColor: false };
+
+  var greenCars = dealership.get('carsGroupedByColor').objectAt(2);
+  greenCars.set('originalColor', false);
+
+  var result = dealership.get('carsGroupedByColor');
+  var expected = [redGroup, blueGroup, greenGroup];
+
+  assert.equal(result.objectAt(0).property, expected[0].property);
+  assert.equal(result.objectAt(0).value, expected[0].value);
+  assert.equal(result.objectAt(0).originalColor, expected[0].originalColor);
+  assert.deepEqual(result.objectAt(0).items, expected[0].items);
+
+  assert.equal(result.objectAt(1).property, expected[1].property);
+  assert.equal(result.objectAt(1).value, expected[1].value);
+  assert.equal(result.objectAt(1).originalColor, expected[1].originalColor);
+  assert.deepEqual(result.objectAt(1).items, expected[1].items);
+
+  assert.equal(result.objectAt(2).property, expected[2].property);
+  assert.equal(result.objectAt(2).value, expected[2].value);
+  assert.equal(result.objectAt(2).originalColor, expected[2].originalColor);
+  assert.deepEqual(result.objectAt(2).items, expected[2].items);
 });


### PR DESCRIPTION
I added some extra functionality to the groups. Now, when the groups are created, they can get some additional properties which can be `get()` and `set()` in a controller. Properties can be "basic" properties (string, number) or functions (e.g. `getGroupSize()`).

I also added a unit test for this. Unfortunately I also had to fix the existing unit tests, since `deepEqual()` did not work as expected anymore.
