### PR TITLE
Allow passing in additional keys for recomputing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,17 @@ You can then use this in your templates to do cool things like:
 {{/each}}
 ```
 
+
+You can also pass additional keys in for the computed property to watch. This
+will cause it to re-compute when any of those keys change.
+
+```javascript
+import Ember from 'ember';
+import groupBy from 'ember-group-by';
+
+export default Ember.Controller.extend({
+  carsByColor: groupBy('model', 'color', { additionalKeysToWatch: ['price', 'name'] })
+});
+
+
 **There is also an example in [test/dummy](tests/dummy).**

--- a/addon/macros/group-by.js
+++ b/addon/macros/group-by.js
@@ -5,21 +5,29 @@ var computed = Ember.computed;
 var get = Ember.get;
 var isPresent = Ember.isPresent;
 
-export default function groupBy(collection, property) {
-  var dependentKey = collection + '.@each.' + property;
+export default function groupBy(collection, groupingProperty, options = {}) {
+  var dependentKey;
+
+  if(options.additionalPropertiesToWatch) {
+    options.additionalPropertiesToWatch.push(groupingProperty);
+    var propertyString = '{' + options.additionalPropertiesToWatch + '}';
+    dependentKey = collection + '.@each.' + propertyString;
+  } else {
+    dependentKey = collection + '.@each.' + groupingProperty;
+  }
 
   return computed(dependentKey, function() {
     var groups = new A();
     var items = get(this, collection);
 
     items.forEach(function(item) {
-      var value = get(item, property);
+      var value = get(item, groupingProperty);
       var group = groups.findBy('value', value);
 
       if (isPresent(group)) {
         get(group, 'items').push(item);
       } else {
-        group = { property: property, value: value, items: [item] };
+        group = { property: groupingProperty, value: value, items: [item] };
         groups.push(group);
       }
     });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -2,5 +2,5 @@ import Ember from 'ember';
 import groupBy from 'ember-group-by';
 
 export default Ember.Controller.extend({
-  carsByColor: groupBy('model', 'color')
+  carsByColor: groupBy('model', 'color', { additionalPropertiesToWatch: ["name", "year"] })
 });


### PR DESCRIPTION
I ran into an issue where the cache was not busting when I changed a value that was not the grouping value. This solves the issue I was running into and may be helpful for others.

I apologize for the lack of tests but I couldn't figure out a way to properly unit test this functionality.
