### PR TITLE
remove usage of deprecated new A()

### DIFF
--- a/addon/macros/group-by.js
+++ b/addon/macros/group-by.js
@@ -6,7 +6,7 @@ export default function groupBy(collection, property) {
   let dependentKey = collection + '.@each.' + property;
 
   return computed(dependentKey, function() {
-    let groups = new A();
+    let groups = A();
     let items = get(this, collection);
 
     if (items) {


### PR DESCRIPTION
`new A()` is deprecated